### PR TITLE
Updates for the move to the dotnet GitHub org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/xamarin/xamarin-android-binutils/actions/workflows/ci.yml/badge.svg)](https://github.com/xamarin/xamarin-android-binutils/actions/workflows/ci.yml)
+[![CI](https://devdiv.visualstudio.com/DevDiv/_apis/build/status%2FXamarin%2FAndroid%2Fxamarin-android-binutils?repoName=dotnet%2Fandroid-native-tools&branchName=main)](https://devdiv.visualstudio.com/DevDiv/_build/latest?definitionId=17684&repoName=dotnet%2Fandroid-native-tools&branchName=main)
 
 # Binary utilities for Xamarin.Android 
 

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -19,7 +19,7 @@ resources:
     endpoint: xamarin
   - repository: xa-yaml
     type: github
-    name: xamarin/xamarin-android
+    name: dotnet/android
     ref: refs/heads/main
     endpoint: xamarin
   - repository: 1esPipelines
@@ -145,8 +145,10 @@ extends:
             name: Azure Pipelines
             vmImage: macOS-latest
           ${{ else }}:
-            name: VSEng-Xamarin-RedmondMac-Android-Untrusted
-            demands: macOS.Name -equals Monterey
+            name: VSEng-VSMac-Xamarin-Shared
+            demands:
+            - macOS.Name -equals Ventura
+            - macOS.Architecture -equals x64
           os: macOS
         templateContext:
           outputs:

--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -68,7 +68,7 @@ function prepare()
 	cat <<EOF
 Next steps:
 
-  * Go to https://github.com/xamarin/xamarin-android-binutils/releases
+  * Go to https://github.com/dotnet/android-native-tools/releases
   * Create new release using the '${tag_name}' tag
   * Upload ${dest_archive} to that release
 EOF

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,8 +12,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE BOOL "" FORCE)
 project(
   xa-utilities
   VERSION ${XA_UTILS_VERSION}
-  DESCRIPTION "Xamarin.Android toolchain utilities"
-  HOMEPAGE_URL "https://github.com/xamarin/xamarin-android-binutils"
+  DESCRIPTION ".NET for Android toolchain utilities"
+  HOMEPAGE_URL "https://github.com/dotnet/android-native-tools"
   LANGUAGES C CXX
   )
 


### PR DESCRIPTION
The android and android-native-tools repos were recently moved to the
dotnet GitHub org. Update URLs and references to the new locations.