### PR TITLE
[ci] Reduce CodeQL scope on signing job

### DIFF
--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -210,6 +210,7 @@ extends:
     - stage: package
       displayName: Package Stage
       #dependsOn: build
+      dependsOn: []
       #condition: or(eq(dependencies.build.result, 'Succeeded'), eq(dependencies.build.result, 'SucceededWithIssues'))
       jobs:
       - job: pack_sign

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -209,9 +209,8 @@ extends:
 
     - stage: package
       displayName: Package Stage
-      #dependsOn: build
-      dependsOn: []
-      #condition: or(eq(dependencies.build.result, 'Succeeded'), eq(dependencies.build.result, 'SucceededWithIssues'))
+      dependsOn: build
+      condition: or(eq(dependencies.build.result, 'Succeeded'), eq(dependencies.build.result, 'SucceededWithIssues'))
       jobs:
       - job: pack_sign
         displayName: Sign and Zip

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -221,10 +221,6 @@ extends:
           vmImage: macOS-latest
           os: macOS
         templateContext:
-          sdl:
-          codeql:
-            compiled:
-              enabled: false
           outputParentDirectory: $(Build.StagingDirectory)
           outputs:
           - output: pipelineArtifact
@@ -240,6 +236,15 @@ extends:
         steps:
         - checkout: self
           submodules: recursive
+
+        # Run CodeQL init and finalize before signing to avoid timeouts and conflicts with the codeql and signing tooling
+        - task: CodeQL3000Init@0
+          displayName: CodeQL 3000 Init
+          #condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+
+        - task: CodeQL3000Finalize@0
+          displayName: CodeQL 3000 Finalize
+          #condition: and(succeededOrFailed(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
         - template: build-tools/automation/yaml-templates/install-microbuild-tooling.yaml@xa-yaml
           parameters:

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -72,8 +72,6 @@ extends:
         enableAllTools: false
       binskim:
         scanOutputDirectoryOnly: true
-      codeql:
-        runSourceLanguagesInSourceAnalysis: true
       suppression:
         suppressionFile: $(Build.SourcesDirectory)\.gdn\.gdnsuppress
       sourceAnalysisPool:
@@ -193,9 +191,6 @@ extends:
           name: MAUI-1ESPT
           image: $(WindowsPoolImage1ESPT)
           os: windows
-        variables:
-        - name: Codeql.Enabled
-          value: true
         templateContext:
           outputs:
           - output: pipelineArtifact
@@ -214,7 +209,8 @@ extends:
 
     - stage: package
       displayName: Package Stage
-      dependsOn: build
+      #dependsOn: build
+      #condition: or(eq(dependencies.build.result, 'Succeeded'), eq(dependencies.build.result, 'SucceededWithIssues'))
       jobs:
       - job: pack_sign
         displayName: Sign and Zip

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -224,6 +224,10 @@ extends:
           vmImage: macOS-latest
           os: macOS
         templateContext:
+          sdl:
+          codeql:
+            compiled:
+              enabled: false
           outputParentDirectory: $(Build.StagingDirectory)
           outputs:
           - output: pipelineArtifact

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -239,11 +239,9 @@ extends:
         # Run CodeQL init and finalize before signing to avoid timeouts and conflicts with the codeql and signing tooling
         - task: CodeQL3000Init@0
           displayName: CodeQL 3000 Init
-          #condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
         - task: CodeQL3000Finalize@0
           displayName: CodeQL 3000 Finalize
-          #condition: and(succeededOrFailed(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
         - template: build-tools/automation/yaml-templates/install-microbuild-tooling.yaml@xa-yaml
           parameters:


### PR DESCRIPTION
Recent signing attempts have been timing out, and we've seen issues in
the past with CodeQL interfering with signing jobs.

Running the CodeQL init and finalize steps at the start of the signing
job before any signing steps run will hopefully prevent these timeouts.