### PR TITLE
[ci] Disable CodeQL on signing stage

### DIFF
--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -60,6 +60,8 @@ variables:
   value: 1ESPT-Ubuntu20.04
 - name: MicroBuildPoolName
   value: VSEngSS-MicroBuild2022-1ES
+- name: Codeql.Enabled
+  value: false
 
 extends:
   ${{ if or(eq(variables['Build.Reason'], 'PullRequest'), eq('${{ parameters.Skip1ESComplianceTasks }}', 'true')) }}:
@@ -90,6 +92,8 @@ extends:
           image: $(LinuxPoolImage1ESPT)
           os: linux
         variables:
+        - name: Codeql.Enabled
+          value: true
         - name: Codeql.BuildIdentifier
           value: build_linux
         templateContext:
@@ -152,6 +156,8 @@ extends:
             - macOS.Architecture -equals x64
           os: macOS
         variables:
+        - name: Codeql.Enabled
+          value: true
         - name: Codeql.BuildIdentifier
           value: build_macos
         templateContext:
@@ -198,6 +204,8 @@ extends:
           image: $(WindowsPoolImage1ESPT)
           os: windows
         variables:
+        - name: Codeql.Enabled
+          value: true
         - name: Codeql.BuildIdentifier
           value: build_windows
         templateContext:
@@ -229,9 +237,6 @@ extends:
           name: Azure Pipelines
           vmImage: macOS-latest
           os: macOS
-        variables:
-        - name: Codeql.SkipTaskAutoInjection
-          value: true
         templateContext:
           #sdl:
           #  codeql:

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -209,8 +209,15 @@ extends:
 
     - stage: package
       displayName: Package Stage
-      dependsOn: build
-      condition: or(eq(dependencies.build.result, 'Succeeded'), eq(dependencies.build.result, 'SucceededWithIssues'))
+      dependsOn: []
+      #dependsOn: build
+      #condition: or(eq(dependencies.build.result, 'Succeeded'), eq(dependencies.build.result, 'SucceededWithIssues'))
+      templateContext:
+        sdl:
+          codeql:
+            compiled:
+              enabled: false
+              justificationForDisabling: CodeQL is causing issues with signing and is only enabled in build stages
       jobs:
       - job: pack_sign
         displayName: Sign and Zip
@@ -235,17 +242,6 @@ extends:
         steps:
         - checkout: self
           submodules: recursive
-
-        # Run CodeQL init and finalize before signing to avoid timeouts and conflicts with the codeql and signing tooling
-        - task: CodeQL3000Init@0
-          displayName: CodeQL 3000 Init
-
-        - task: CodeQL3000Finalize@0
-          displayName: CodeQL 3000 Finalize
-
-        - template: build-tools/automation/yaml-templates/install-microbuild-tooling.yaml@xa-yaml
-          parameters:
-            condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
 
         - task: DownloadPipelineArtifact@2
           inputs:
@@ -275,7 +271,7 @@ extends:
             arguments: >-
               -t:Build,ZipOutput
               -p:SignType=$(MicroBuildSignType)
-              -bl:$(Build.StagingDirectory)/binlogs/sign-macos.binlog
+              -bl:$(Build.StagingDirectory)/binlogs/sign-macos.binlog -v:n
 
         - template: build-tools/automation/yaml-templates/remove-microbuild-tooling.yaml@xa-yaml
           parameters:

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -89,6 +89,9 @@ extends:
           name: MAUI-1ESPT
           image: $(LinuxPoolImage1ESPT)
           os: linux
+        variables:
+        - name: Codeql.BuildIdentifier
+          value: build_linux
         templateContext:
           outputs:
           - output: pipelineArtifact
@@ -148,6 +151,9 @@ extends:
             - macOS.Name -equals Ventura
             - macOS.Architecture -equals x64
           os: macOS
+        variables:
+        - name: Codeql.BuildIdentifier
+          value: build_macos
         templateContext:
           outputs:
           - output: pipelineArtifact
@@ -191,6 +197,9 @@ extends:
           name: MAUI-1ESPT
           image: $(WindowsPoolImage1ESPT)
           os: windows
+        variables:
+        - name: Codeql.BuildIdentifier
+          value: build_windows
         templateContext:
           outputs:
           - output: pipelineArtifact
@@ -212,12 +221,15 @@ extends:
       dependsOn: []
       #dependsOn: build
       #condition: or(eq(dependencies.build.result, 'Succeeded'), eq(dependencies.build.result, 'SucceededWithIssues'))
-      templateContext:
-        sdl:
-          codeql:
-            compiled:
-              enabled: false
-              justificationForDisabling: CodeQL is causing issues with signing and is only enabled in build stages
+      variables:
+      - name: Codeql.SkipTaskAutoInjection
+        value: true
+      #templateContext:
+      #  sdl:
+      #    codeql:
+      #      compiled:
+      #        enabled: false
+      #        justificationForDisabling: CodeQL is causing issues with signing and is only enabled in build stages
       jobs:
       - job: pack_sign
         displayName: Sign and Zip

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -60,8 +60,6 @@ variables:
   value: 1ESPT-Ubuntu20.04
 - name: MicroBuildPoolName
   value: VSEngSS-MicroBuild2022-1ES
-- name: Codeql.Enabled
-  value: false
 
 extends:
   ${{ if or(eq(variables['Build.Reason'], 'PullRequest'), eq('${{ parameters.Skip1ESComplianceTasks }}', 'true')) }}:
@@ -91,11 +89,6 @@ extends:
           name: MAUI-1ESPT
           image: $(LinuxPoolImage1ESPT)
           os: linux
-        variables:
-        - name: Codeql.Enabled
-          value: true
-        - name: Codeql.BuildIdentifier
-          value: build_linux
         templateContext:
           outputs:
           - output: pipelineArtifact
@@ -155,11 +148,6 @@ extends:
             - macOS.Name -equals Ventura
             - macOS.Architecture -equals x64
           os: macOS
-        variables:
-        - name: Codeql.Enabled
-          value: true
-        - name: Codeql.BuildIdentifier
-          value: build_macos
         templateContext:
           outputs:
           - output: pipelineArtifact
@@ -203,11 +191,6 @@ extends:
           name: MAUI-1ESPT
           image: $(WindowsPoolImage1ESPT)
           os: windows
-        variables:
-        - name: Codeql.Enabled
-          value: true
-        - name: Codeql.BuildIdentifier
-          value: build_windows
         templateContext:
           outputs:
           - output: pipelineArtifact
@@ -229,6 +212,9 @@ extends:
       dependsOn: []
       #dependsOn: build
       #condition: or(eq(dependencies.build.result, 'Succeeded'), eq(dependencies.build.result, 'SucceededWithIssues'))
+      variables:
+      - name: ONEES_ENFORCED_CODEQL_ENABLED
+        value: false
       jobs:
       - job: pack_sign
         displayName: Sign and Zip
@@ -237,6 +223,7 @@ extends:
           name: Azure Pipelines
           vmImage: macOS-latest
           os: macOS
+
         templateContext:
           #sdl:
           #  codeql:

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -247,16 +247,31 @@ extends:
           inputs:
             artifactName: artifacts-linux-unsigned
             downloadPath: artifacts
+            buildType: 'specific'
+            project: 'DevDiv'
+            definition: 17684
+            buildVersionToDownload: 'specific'
+            pipelineId: 10108866
 
         - task: DownloadPipelineArtifact@2
           inputs:
             artifactName: artifacts-macos-unsigned
             downloadPath: artifacts
+            buildType: 'specific'
+            project: 'DevDiv'
+            definition: 17684
+            buildVersionToDownload: 'specific'
+            pipelineId: 10108866
 
         - task: DownloadPipelineArtifact@2
           inputs:
             artifactName: artifacts-windows-unsigned
             downloadPath: artifacts
+            buildType: 'specific'
+            project: 'DevDiv'
+            definition: 17684
+            buildVersionToDownload: 'specific'
+            pipelineId: 10108866
 
         - task: CmdLine@2
           inputs:

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -209,10 +209,10 @@ extends:
 
     - stage: package
       displayName: Package Stage
-      dependsOn: []
-      #dependsOn: build
-      #condition: or(eq(dependencies.build.result, 'Succeeded'), eq(dependencies.build.result, 'SucceededWithIssues'))
+      dependsOn: build
+      condition: or(eq(dependencies.build.result, 'Succeeded'), eq(dependencies.build.result, 'SucceededWithIssues'))
       variables:
+      # Disable CodeQL on the signing stage to avoid timeouts and conflicts with the codeql and signing tooling
       - name: ONEES_ENFORCED_CODEQL_ENABLED
         value: false
       jobs:
@@ -223,13 +223,7 @@ extends:
           name: Azure Pipelines
           vmImage: macOS-latest
           os: macOS
-
         templateContext:
-          #sdl:
-          #  codeql:
-          #    compiled:
-          #      enabled: false
-          #      justificationForDisabling: CodeQL is causing issues with signing and is only enabled in build stages
           outputParentDirectory: $(Build.StagingDirectory)
           outputs:
           - output: pipelineArtifact
@@ -246,35 +240,25 @@ extends:
         - checkout: self
           submodules: recursive
 
+        - template: build-tools/automation/yaml-templates/install-microbuild-tooling.yaml@xa-yaml
+          parameters:
+            condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
+
         - task: DownloadPipelineArtifact@2
           inputs:
             artifactName: artifacts-linux-unsigned
             downloadPath: artifacts
-            buildType: 'specific'
-            project: 'DevDiv'
-            definition: 17684
-            buildVersionToDownload: 'specific'
-            pipelineId: 10108866
 
         - task: DownloadPipelineArtifact@2
           inputs:
             artifactName: artifacts-macos-unsigned
             downloadPath: artifacts
-            buildType: 'specific'
-            project: 'DevDiv'
-            definition: 17684
-            buildVersionToDownload: 'specific'
-            pipelineId: 10108866
 
         - task: DownloadPipelineArtifact@2
           inputs:
             artifactName: artifacts-windows-unsigned
             downloadPath: artifacts
-            buildType: 'specific'
-            project: 'DevDiv'
-            definition: 17684
-            buildVersionToDownload: 'specific'
-            pipelineId: 10108866
+
 
         - task: CmdLine@2
           inputs:

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -259,7 +259,6 @@ extends:
             artifactName: artifacts-windows-unsigned
             downloadPath: artifacts
 
-
         - task: CmdLine@2
           inputs:
             script: ./package.sh

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -221,15 +221,6 @@ extends:
       dependsOn: []
       #dependsOn: build
       #condition: or(eq(dependencies.build.result, 'Succeeded'), eq(dependencies.build.result, 'SucceededWithIssues'))
-      variables:
-      - name: Codeql.SkipTaskAutoInjection
-        value: true
-      #templateContext:
-      #  sdl:
-      #    codeql:
-      #      compiled:
-      #        enabled: false
-      #        justificationForDisabling: CodeQL is causing issues with signing and is only enabled in build stages
       jobs:
       - job: pack_sign
         displayName: Sign and Zip
@@ -238,7 +229,15 @@ extends:
           name: Azure Pipelines
           vmImage: macOS-latest
           os: macOS
+        variables:
+        - name: Codeql.SkipTaskAutoInjection
+          value: true
         templateContext:
+          #sdl:
+          #  codeql:
+          #    compiled:
+          #      enabled: false
+          #      justificationForDisabling: CodeQL is causing issues with signing and is only enabled in build stages
           outputParentDirectory: $(Build.StagingDirectory)
           outputs:
           - output: pipelineArtifact


### PR DESCRIPTION
Commit 4afff71d did not resolve the timeout issues we've been seeing
during the signing job. We will now attempt to disable CodeQL entirely
on this stage to resolve the timeouts.